### PR TITLE
Fix for Sys::SigAction::Alarm::ssa_alarm() "too big" comparison and tests

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -139,7 +139,7 @@ sub ssa_alarm($)
    my $secs = shift;
    #print  print "secs=$secs\n";
 
-   if ( $hrworks and ($secs le (INT_MAX()/1_000_000.0) ) )
+   if ( $hrworks and ($secs <= (INT_MAX()/1_000_000.0) ) )
    {
       Time::HiRes::ualarm( $secs * 1_000_000 );
    }

--- a/t/timeout.t
+++ b/t/timeout.t
@@ -144,7 +144,7 @@ else
 
    #diag( "Testing HiRes where msecs is greater than maxint (" .POSIX::INT_MAX().")" );
    my $toobig = INT_MAX();
-   $toobig = ($toobig/1_000_000.0) + 1.1;
+   $toobig = (1 . 0 x length INT_MAX()) / 1_000_000;
    $ret = 0;
    eval { 
       $ret = timeout_call( $toobig, \&sleep_one ); 


### PR DESCRIPTION
The current code does a lexical comparison, which results in errors for timeouts that are lexically before MAX_INT() but numerically after. For example a 3 hour (10800 second) timeout when compared lexically to MAX_INT()/1_000_000 (about 2147 on my system) passes the test, calls Time::HiRes::ualarm() and fails with:

   Time::HiRes::ualarm(-2084901888, 0): negative time not invented yet at tmp/Sys/SigAction/Alarm.pm line 20

This change uses the numerical comparison operator '<=' and changes the unit test to use the smallest number that is both numerically after and lexically before MAX_INT().